### PR TITLE
Allow override of `window` in config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ function AirbrakeMini (config) {
   this.environment = config.environment || DEFAULT_ENVIRONMENT
   this.reporter = config.reporter || new Reporter(config)
   this.filters = []
+  this.window = config.window || window;
 }
 
 AirbrakeMini.prototype.createInitialPayload = function airbrakeCreateInitialPayload () {
@@ -24,9 +25,9 @@ AirbrakeMini.prototype.createInitialPayload = function airbrakeCreateInitialPayl
     id: '',
     context: {
       notifier: NOTIFIER,
-      userAgent: window.navigator.userAgent,
-      url: window.location.href,
-      rootDirectory: window.location.protocol + '//' + window.location.host,
+      userAgent: this.window.navigator.userAgent,
+      url: this.window.location.href,
+      rootDirectory: this.window.location.protocol + '//' + this.window.location.host,
       language: 'JavaScript',
       environment: this.environment,
       severity: 'error',

--- a/test/airbrake-mini.test.js
+++ b/test/airbrake-mini.test.js
@@ -67,4 +67,23 @@ describe('airbrake mini', () => {
     assert.equal(enrichedObject.context.notifier.name, 'airbrake-mini-client')
     assert.typeOf(enrichedObject.context.userAgent, 'string')
   })
+
+  it('allows override of window', () => {
+    var userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36'
+    var href = 'https://github.com/tes/airbrake-mini-client'
+    var protocol = 'https:'
+    var host = 'github.com'
+    var windowOverride = { navigator: { userAgent }, location: { href, protocol, host } }
+    airbrake = new AirbrakeMini({
+      projectId: '123',
+      projectKey: '456',
+      reporter: reporter,
+      window: windowOverride
+    })
+    var enrichedObject = airbrake.createInitialPayload()
+
+    assert.equal(enrichedObject.context.userAgent, userAgent)
+    assert.equal(enrichedObject.context.url, href)
+    assert.equal(enrichedObject.context.rootDirectory, `${protocol}//${host}`)
+  })
 })


### PR DESCRIPTION
To enable airbrake-mini-client to be used in tests where global `window` is unavailable